### PR TITLE
Added Coupling Map Information to Default Configuration

### DIFF
--- a/qiskit_jku_provider/qasm_simulator_jku.py
+++ b/qiskit_jku_provider/qasm_simulator_jku.py
@@ -297,6 +297,7 @@ class QasmSimulator(BaseBackend):
         'n_qubits': 30,
         'conditional': False,
         'max_shots': 100000,
+        'coupling_map': None,
         'open_pulse': False,
         'gates': [
             {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Added coupling map to the default configuration as is required from the backend configuration( fixes #73 )


### Details and comments

Without defining the coupling map `TypeError: init() missing 1 required positional argument: 'coupling_map'` is raised in `qiskit/providers/models/backendconfiguration.py`. Setting the coupling map to `None` as the simulator is not restricted in regards to qubit interactions, fixes the problem.

Please let me know if I missed anything for this PR to be accepted.